### PR TITLE
Brand url

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ On mobile, a dropdown burger is rendered using javascript. If the page detects j
 
 ### Brand
 
-In extra, setting `zulma_brand` will cause a brand image to display in the upper left of the top menu bar. This link will always lead back to the homepage. It has two parameters, `image`(optional) and `text`(required). `image` will set the brand to an image at the location specified, and `text` will provide the alt text for this image. If you put \$BASE_URL in a url, it will automatically be replaced by the actual site URL. If `image` is not set, the brand will simply be the text specified.
+In extra, setting `zulma_brand` will cause a brand image to display in the upper left of the top menu bar. By default, this link will lead back to the homepage (root "/" of the website). It has three parameters, `image`(optional), `url` (optional), and `text`(required). `image` will set the brand to an image at the location specified, and `text` will provide the alt text for this image. `url` will override the link to the specified URL rather than the root of the website. If you put \$BASE_URL in a url, it will automatically be replaced by the actual site URL. If `image` is not set, the brand will simply be the text specified.
 
 ```toml
 [extra]
-zulma_brand = {image = "$BASE_URL/images/bulma.png", text = "Home"}
+zulma_brand = {image = "$BASE_URL/images/bulma.png", url = "$BASE_URL", text = "Home"}
 ```
 
 ### Search

--- a/templates/index_macros.html
+++ b/templates/index_macros.html
@@ -58,7 +58,12 @@
         <div class="container">
             <div class="navbar-brand">
                 {% if config.extra.zulma_brand %}
-                <a class="navbar-item" href="/">
+                {% if config.extra.zulma_brand.url %}
+                {% set brand_url = config.extra.zulma_brand.url | safe | replace(from="$BASE_URL", to=config.base_url) %}
+                {% else %}
+                {% set brand_url = "/" %}
+                {% endif %}
+                <a class="navbar-item" href="{{ brand_url }}">
                     {% if config.extra.zulma_brand.image %}
                     <img src="{{ config.extra.zulma_brand.image | safe | replace(from="$BASE_URL", to=config.base_url) }}"
                         alt="{{ config.extra.zulma_brand.text }}">


### PR DESCRIPTION
Hello,

Thank you for making Zulma! I'm using it in a project of mine, and I'm glad this theme exists.

However, my project is to, at least temporarily, be updated on gitlab pages.
This means its URL will be something like `dureuill.gitlab.io/<name_of_project>`. With the current code, this results in the brand logo linking to `dureuill.gitlab.io`, which is a 404 (and cannot be anything else, to my knowledge).

Therefore, this small PR does the following:

- If the `config.zulma_brand.url` configuration variable exists, use it as target URL in the brand logo (by replacing `$BASE_URL` by the `config.base_url` variable like in the `config.zulma_brand.image` variable) 
- Otherwise, keep the current behavior of using `/` as target URL in the brand logo.
- Updates the documentation about brand in the README.

I would appreciate if you could consider merging this PR into Zulma.
Feel free to modify the proposed PR to your liking, especially regarding the documentation.

Thanks again for making Zulma!