### PR TITLE
Fix Netlify Redirect

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -2,7 +2,7 @@ name = "Zulma"
 description = "A zola theme based off bulma.css"
 license = "MIT"
 min_version = "0.6.0"
-demo = "https://festive-morse-47d46c.netlify.com/"
+demo = "https://festive-morse-47d46c.netlify.app/"
 homepage = "https://github.com/Worble/Zulma"
 
 [extra]


### PR DESCRIPTION
Netlify is redirecting all .com to .app, this is affecting the demo by making every link redirect, you can test by navigating pages on the current demo.

You will also need to update the config.toml to be .app instead of .com  but it seems this repo does not currently directly build the demo, in config.toml I see

```toml
base_url = "https://example.com"
```

https://github.com/Worble/Zulma/blob/c21216b8a815788dbcbf807de8d97ed9cc00f95c/config.toml#L2