### PR TITLE
templates/index: add block to customize page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -66,6 +66,9 @@
         {% endif %}
         <!-- END HERO TITLE -->
         <div class="container">
+            {% block extra_content %}
+            {% endblock extra_content %}
+
             <!-- START ARTICLE FEED -->
             {% if paginator %}
             {{ index_macros::list_articles(pages=paginator.pages) }}


### PR DESCRIPTION
Add an `extra_content` empty block to allow users to add content to the page.